### PR TITLE
Adding working mixtral 2.5 jinja -- tested and working.

### DIFF
--- a/mixtral.jinja
+++ b/mixtral.jinja
@@ -1,0 +1,12 @@
+{% for message in messages %}
+  {% if message['role'] == 'user' %}
+    ### Instruction:
+    <s>[INST] {{ message['content'] | trim }} [/INST]
+  {% elif message['role'] == 'assistant' %}
+    ### Response:
+    {{ message['content'] | trim }}
+  {% endif %}
+{% endfor %}
+{% if add_generation_prompt and messages[-1]['role'] != 'assistant' %}
+    <s>[INST]### Response Placeholder: [/INST]
+{% endif %}


### PR DESCRIPTION
Tested with Mixtral 2.5

Enhance the formatting of messages within the mixtral.jinja template file. The primary focus is on making instructions and responses more readable and structured.

Messages are categorized into instructions (user messages) and responses (assistant messages) based on their roles.

Instructions are enclosed within [INST] and [/INST] tags to clearly identify them as user instructions.

Responses are displayed without any additional tags or formatting.

Improved spacing and line breaks for better message separation.

It can be customized and tuned to do much more with prompt modifications, however, this one works well so far.
