### PR TITLE
Add modified mixtral-instruct.jinja template to support system role

### DIFF
--- a/mixtral-instruct.jinja
+++ b/mixtral-instruct.jinja
@@ -1,0 +1,13 @@
+{{ bos_token }}
+{% for message in messages %}
+    {% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}
+        {{raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}
+    {% endif %}
+    {% if message['role'] == 'user' %}
+        {{ '[INST] ' + message['content'] + ' [/INST]' }}
+    {% elif message['role'] == 'assistant' %}
+        {{ message['content'] + eos_token}}
+    {% else %}
+        {{ raise_exception('Only user and assistant roles are supported!') }}
+    {% endif %}
+{% endfor %}

--- a/mixtral-instruct.jinja
+++ b/mixtral-instruct.jinja
@@ -1,12 +1,17 @@
 {{ bos_token }}
-{% for message in messages %}
+{% set has_system = 0 %}
+{% if messages[0]['role'] == 'system' %}
+    {% set has_system = 1 %}
+    {{ '[INST] ' + messages[0]['content'] + ' [/INST]' }}
+{% endif %}
+{% for message in messages[has_system:] %}
     {% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}
-        {{raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}
+        {{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}
     {% endif %}
     {% if message['role'] == 'user' %}
         {{ '[INST] ' + message['content'] + ' [/INST]' }}
     {% elif message['role'] == 'assistant' %}
-        {{ message['content'] + eos_token}}
+        {{ message['content'] + eos_token }}
     {% else %}
         {{ raise_exception('Only user and assistant roles are supported!') }}
     {% endif %}


### PR DESCRIPTION
Commit history has the original template as provided by Mistral AI themselves for Mixtral-Instruct-8x7b.  Template was modified to add an unofficial "system" role to allow for system prompts to be used with the instruct model.