### PR TITLE
Add cohere-command-r template

### DIFF
--- a/cohere-command-r.jinja
+++ b/cohere-command-r.jinja
@@ -1,0 +1,32 @@
+{{- bos_token -}}
+{% if bos_token|length > 0 %}
+    {{- '\n' -}}
+{% endif %}
+{% if messages[0]['role'] == 'system' %}
+    {% set loop_messages = messages[1:] %}
+    {% set system_message = messages[0]['content'] %}
+{% elif use_default_system_prompt == true %}
+    {% set loop_messages = messages %}
+    {% set system_message = 'You are Command-R, a brilliant, sophisticated, AI-assistant trained to assist human users by providing thorough responses. You are trained by Cohere.' %}
+{% else %}
+    {% set loop_messages = messages %}
+    {% set system_message = false %}
+{% endif %}
+{% if system_message != false %}
+    {{- '<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>' + system_message + '<|END_OF_TURN_TOKEN|>' }}
+{% endif %}
+{% for message in loop_messages %}
+    {% set content = message['content'] %}
+    {% if message['role'] == 'user' %}
+        {{- '<|START_OF_TURN_TOKEN|><|USER_TOKEN|>' + content.strip() + '<|END_OF_TURN_TOKEN|>' }}
+    {% elif message['role'] == 'assistant' %}
+        {{- '<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>'  + content.strip() + '<|END_OF_TURN_TOKEN|>' }}
+    {% elif message['role'] == 'system' %}
+        {{- '<|START_OF_TURN_TOKEN|><|SYSTEM_TOKEN|>' + content.strip() + '<|END_OF_TURN_TOKEN|>' }}
+    {% else %}
+        {{ raise_exception('Only user, assistant, and system roles are supported!') }}
+    {% endif %}
+{% endfor %}
+{% if add_generation_prompt %}
+    {{- '<|START_OF_TURN_TOKEN|><|CHATBOT_TOKEN|>' -}}
+{% endif %}


### PR DESCRIPTION
* Supports use_default_system_prompt to inject the default Cohere system prompt if no system prompt is provided in the first message of the conversation
* More flexible than the official template, allowing for user, assistant, and system messages to appear in any order in the conversation